### PR TITLE
Season Service Added

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,10 +1,12 @@
 import { tfPlayer } from './track-field/tf-player/tf-player'
 import { tfTeam } from './track-field/tf-team/tf-team'
+import { tfSeason } from './track-field/tf-season/tf-season'
 // For more information about this file see https://dove.feathersjs.com/guides/cli/application.html#configure-functions
 import type { Application } from '../declarations'
 
 export const services = (app: Application) => {
   app.configure(tfPlayer)
   app.configure(tfTeam)
+  app.configure(tfSeason)
   // All services will be registered here
 }

--- a/src/services/track-field/tf-season/tf-season.class.ts
+++ b/src/services/track-field/tf-season/tf-season.class.ts
@@ -1,0 +1,23 @@
+import type { Application } from '../../../declarations'
+import type { Params } from '@feathersjs/feathers'
+import { KnexService } from '@feathersjs/knex'
+import type { KnexAdapterParams, KnexAdapterOptions } from '@feathersjs/knex'
+import type { Season, SeasonData, SeasonPatch, SeasonQuery } from './tf-season.schema'
+export type { Season, SeasonData, SeasonPatch, SeasonQuery }
+
+export interface SeasonParams extends KnexAdapterParams<SeasonQuery> {}
+// By default calls the standard Knex adapter service methods but can be customized with your own functionality.
+export class SeasonService<ServiceParams extends Params = SeasonParams> extends KnexService<
+  Season,
+  SeasonData,
+  SeasonParams,
+  SeasonPatch
+> {}
+
+export const getOptions = (app: Application): KnexAdapterOptions => {
+    return {
+      paginate: app.get('paginate'),
+      Model: app.get('mysqlClient'),
+      name: 'ctfc_season'
+    }
+  }

--- a/src/services/track-field/tf-season/tf-season.schema.ts
+++ b/src/services/track-field/tf-season/tf-season.schema.ts
@@ -1,0 +1,64 @@
+// // For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
+import { resolve } from '@feathersjs/schema'
+import { Type, getValidator, querySyntax } from '@feathersjs/typebox'
+import type { Static } from '@feathersjs/typebox'
+
+import type { HookContext } from '../../../declarations'
+import { dataValidator, queryValidator } from '../../../validators'
+import { toLowerCaseProperty } from '../../../utilities/property-name-converter';
+
+
+// Main data model schema
+
+export const seasonSchema = Type.Object(
+    {
+      id: Type.Number(),
+      name: Type.String(),
+      date: Type.String({ format: 'date' }),
+      venue: Type.String()
+    },
+    { $id: 'Season', additionalProperties: false }
+  )
+  
+
+export type Season = Static<typeof seasonSchema>
+export const seasonValidator = getValidator(seasonSchema, dataValidator)
+export const seasonResolver = resolve<Season, HookContext>({}, {
+  converter: async (rawData) => {
+    return toLowerCaseProperty(rawData, seasonSchema)
+  } 
+});
+
+export const seasonExternalResolver = resolve<Season, HookContext>({})
+
+// Schema for creating new entries
+export const seasonDataSchema = Type.Pick(seasonSchema, ['name'], {
+    $id: 'SeasonData'
+  })
+  export type SeasonData = Static<typeof seasonDataSchema>
+  export const seasonDataValidator = getValidator(seasonDataSchema, dataValidator)
+  export const seasonDataResolver = resolve<Season, HookContext>({})
+  
+  // Schema for updating existing entries
+  export const seasonPatchSchema = Type.Partial(seasonSchema, {
+    $id: 'SeasonPatch'
+  })
+  export type SeasonPatch = Static<typeof seasonPatchSchema>
+  export const seasonPatchValidator = getValidator(seasonPatchSchema, dataValidator)
+  export const seasonPatchResolver = resolve<Season, HookContext>({})
+  
+  // Schema for allowed query properties
+  export const seasonQueryProperties = Type.Pick(seasonSchema, ['id', 'name'])
+  export const seasonQuerySchema = Type.Intersect(
+    [
+      querySyntax(seasonQueryProperties),
+      // Add additional query properties here
+      Type.Object({}, { additionalProperties: false })
+    ],
+    { additionalProperties: false }
+  )
+  export type SeasonQuery = Static<typeof seasonQuerySchema>
+  export const seasonQueryValidator = getValidator(seasonQuerySchema, queryValidator)
+  export const seasonQueryResolver = resolve<SeasonQuery, HookContext>({})
+
+  

--- a/src/services/track-field/tf-season/tf-season.shared.ts
+++ b/src/services/track-field/tf-season/tf-season.shared.ts
@@ -1,0 +1,27 @@
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.shared.html
+import type { Params } from '@feathersjs/feathers'
+import type { ClientApplication } from '../../../client'
+import type { Season, SeasonData, SeasonPatch, SeasonQuery, SeasonService } from './tf-season.class'
+
+export type { Season, SeasonData, SeasonPatch, SeasonQuery }
+
+export type SeasonClientService = Pick<SeasonService<Params<SeasonQuery>>, (typeof seasonMethods)[number]>
+
+export const seasonPath = '/track-field/season'
+
+export const seasonMethods = ['find', 'get', 'create', 'patch', 'remove'] as const
+
+export const seasonClient = (client: ClientApplication) => {
+  const connection = client.get('connection')
+
+  client.use(seasonPath, connection.service(seasonPath), {
+    methods: seasonMethods
+  })
+}
+
+// Add this service to the client service type index
+declare module '../../../client' {
+  interface ServiceTypes {
+    [seasonPath]: SeasonClientService
+  }
+}

--- a/src/services/track-field/tf-season/tf-season.ts
+++ b/src/services/track-field/tf-season/tf-season.ts
@@ -1,0 +1,59 @@
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.html
+
+import { hooks as schemaHooks } from '@feathersjs/schema'
+
+import {
+  seasonDataValidator,
+  seasonPatchValidator,
+  seasonQueryValidator,
+  seasonResolver,
+  seasonExternalResolver,
+  seasonDataResolver,
+  seasonPatchResolver,
+  seasonQueryResolver
+} from './tf-season.schema'
+
+import type { Application } from '../../../declarations'
+import { SeasonService, getOptions } from './tf-season.class'
+import { seasonPath, seasonMethods } from './tf-season.shared'
+
+export * from './tf-season.class'
+export * from './tf-season.schema'
+
+// A configure function that registers the service and its hooks via `app.configure`
+export const tfSeason = (app: Application) => {
+  // Register our service on the Feathers application
+  app.use(seasonPath, new SeasonService(getOptions(app)), {
+    // A list of all methods this service exposes externally
+    methods: seasonMethods,
+    // You can add additional custom events to be sent to clients here
+    events: []
+  })
+  // Initialize hooks
+  app.service(seasonPath).hooks({
+    around: {
+      all: [schemaHooks.resolveExternal(seasonExternalResolver), schemaHooks.resolveResult(seasonResolver)]
+    },
+    before: {
+      all: [schemaHooks.validateQuery(seasonQueryValidator), schemaHooks.resolveQuery(seasonQueryResolver)],
+      find: [],
+      get: [],
+      create: [schemaHooks.validateData(seasonDataValidator), schemaHooks.resolveData(seasonDataResolver)],
+      patch: [schemaHooks.validateData(seasonPatchValidator), schemaHooks.resolveData(seasonPatchResolver)],
+      remove: []
+    },
+    after: {
+      all: []
+    },
+    error: {
+      all: []
+    }
+  })
+}
+
+// Add this service to the service type index
+declare module '../../../declarations' {
+  interface ServiceTypes {
+    [seasonPath]: SeasonService
+  }
+}


### PR DESCRIPTION
## Add season service under the track-field folder

### ctfc_season 
id
name
date
venue


## Screenshot of season service from localhost. 
(only one item in the ctfc_season database for the demo)

<img width="1032" alt="image" src="https://github.com/umliuxin/svcsa-tf-api/assets/100389463/d01d667b-4b53-4f06-ace6-7cb00946e0af">
