### PR TITLE
Track-Field/item Service

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,9 @@ This project uses [Feathers](http://feathersjs.com). An open source framework fo
 
 {{What's the purpose}}
 
+### /track-field/item
+
+{{What's the purpose}}
 
 ## Service Folder Structure
 

--- a/src/services/track-field/item/item.schema.ts
+++ b/src/services/track-field/item/item.schema.ts
@@ -5,6 +5,7 @@ import type { Static } from '@feathersjs/typebox'
 
 import type { HookContext } from '../../../declarations'
 import { dataValidator, queryValidator } from '../../../validators'
+import { toLowerCaseProperty } from '../../../utilities/property-name-converter';
 
 // Main data model schema
 export const tfItemSchema = Type.Object(
@@ -19,7 +20,12 @@ export const tfItemSchema = Type.Object(
 )
 export type TfItem = Static<typeof tfItemSchema>
 export const tfItemValidator = getValidator(tfItemSchema, dataValidator)
-export const tfItemResolver = resolve<TfItem, HookContext>({})
+export const tfItemResolver = resolve<TfItem, HookContext>({}, {
+  converter: async (rawData) => {
+    return toLowerCaseProperty(rawData, tfItemSchema)
+  } 
+});
+
 
 export const tfItemExternalResolver = resolve<TfItem, HookContext>({})
 

--- a/src/services/track-field/item/item.schema.ts
+++ b/src/services/track-field/item/item.schema.ts
@@ -22,18 +22,22 @@ export type TfItem = Static<typeof tfItemSchema>
 export const tfItemValidator = getValidator(tfItemSchema, dataValidator)
 export const tfItemResolver = resolve<TfItem, HookContext>({
   issingle: async (value) => {
-    // Return the photo avatar URL
+
     if(value == "1") {
       return 'true';
+    }else if(value == "0"){
+      return 'false'
     }
-    return 'false';
+    return undefined;
   },
   istrack: async (value) => {
-    // Return the photo avatar URL
+
     if(value == "1") {
       return 'true';
+    }else if(value == "0"){
+      return 'false'
     }
-    return 'false';
+    return undefined;
   },
 }, {
   converter: async (rawData) => {

--- a/src/services/track-field/item/item.schema.ts
+++ b/src/services/track-field/item/item.schema.ts
@@ -10,7 +10,10 @@ import { dataValidator, queryValidator } from '../../../validators'
 export const tfItemSchema = Type.Object(
   {
     id: Type.Number(),
-    text: Type.String()
+    name: Type.String(),
+    issingle: Type.Number(),
+    istrack: Type.Number(),
+    heatsize: Type.Number(),
   },
   { $id: 'TfItem', additionalProperties: false }
 )
@@ -21,7 +24,7 @@ export const tfItemResolver = resolve<TfItem, HookContext>({})
 export const tfItemExternalResolver = resolve<TfItem, HookContext>({})
 
 // Schema for creating new entries
-export const tfItemDataSchema = Type.Pick(tfItemSchema, ['text'], {
+export const tfItemDataSchema = Type.Pick(tfItemSchema, ['name'], {
   $id: 'TfItemData'
 })
 export type TfItemData = Static<typeof tfItemDataSchema>
@@ -37,7 +40,7 @@ export const tfItemPatchValidator = getValidator(tfItemPatchSchema, dataValidato
 export const tfItemPatchResolver = resolve<TfItem, HookContext>({})
 
 // Schema for allowed query properties
-export const tfItemQueryProperties = Type.Pick(tfItemSchema, ['id', 'text'])
+export const tfItemQueryProperties = Type.Pick(tfItemSchema, ['id', 'name', 'issingle','istrack','heatsize'])
 export const tfItemQuerySchema = Type.Intersect(
   [
     querySyntax(tfItemQueryProperties),

--- a/src/services/track-field/item/item.schema.ts
+++ b/src/services/track-field/item/item.schema.ts
@@ -12,15 +12,30 @@ export const tfItemSchema = Type.Object(
   {
     id: Type.Number(),
     name: Type.String(),
-    issingle: Type.Number(),
-    istrack: Type.Number(),
+    issingle: Type.String(),
+    istrack: Type.String(),
     heatsize: Type.Number(),
   },
   { $id: 'TfItem', additionalProperties: false }
 )
 export type TfItem = Static<typeof tfItemSchema>
 export const tfItemValidator = getValidator(tfItemSchema, dataValidator)
-export const tfItemResolver = resolve<TfItem, HookContext>({}, {
+export const tfItemResolver = resolve<TfItem, HookContext>({
+  issingle: async (value) => {
+    // Return the photo avatar URL
+    if(value == "1") {
+      return 'true';
+    }
+    return 'false';
+  },
+  istrack: async (value) => {
+    // Return the photo avatar URL
+    if(value == "1") {
+      return 'true';
+    }
+    return 'false';
+  },
+}, {
   converter: async (rawData) => {
     return toLowerCaseProperty(rawData, tfItemSchema)
   } 


### PR DESCRIPTION
Added Track-Field/item Service. 
allow querying by `id`, `name`, `issingle`, `istrack`, and `heatsize`
